### PR TITLE
feat: Support CoreDNS Wildcards feature of k8s < v1.25

### DIFF
--- a/cmd/all/all.go
+++ b/cmd/all/all.go
@@ -1,6 +1,7 @@
 package all
 
 import (
+	"github.com/esonhugh/k8spider/cmd/wildcard"
 	"net"
 	"os"
 
@@ -27,6 +28,7 @@ var AllCmd = &cobra.Command{
 			log.Warn("cidr is required")
 			return
 		}
+		wildcard.DumpWildCard(command.Opts.Zone)
 		records, err := scanner.DumpAXFR(dns.Fqdn(command.Opts.Zone), "ns.dns."+command.Opts.Zone+":53")
 		if err == nil {
 			printResult(records)
@@ -66,7 +68,7 @@ func RunBatch(net *net.IPNet) {
 
 func printResult(records define.Records) {
 	if command.Opts.OutputFile != "" {
-		f, err := os.OpenFile(command.Opts.OutputFile, os.O_CREATE|os.O_WRONLY, 0644)
+		f, err := os.OpenFile(command.Opts.OutputFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 		if err != nil {
 			log.Warnf("OpenFile failed: %v", err)
 		}

--- a/cmd/axfr/axfr.go
+++ b/cmd/axfr/axfr.go
@@ -42,7 +42,7 @@ var AxfrCmd = &cobra.Command{
 			return
 		}
 		if command.Opts.OutputFile != "" {
-			f, err := os.OpenFile(command.Opts.OutputFile, os.O_CREATE|os.O_WRONLY, 0644)
+			f, err := os.OpenFile(command.Opts.OutputFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 			if err != nil {
 				log.Warnf("OpenFile failed: %v", err)
 			}

--- a/cmd/service/service.go
+++ b/cmd/service/service.go
@@ -29,7 +29,7 @@ var ServiceCmd = &cobra.Command{
 		}
 		records = scanner.ScanSvcForPorts(records)
 		if command.Opts.OutputFile != "" {
-			f, err := os.OpenFile(command.Opts.OutputFile, os.O_CREATE|os.O_WRONLY, 0644)
+			f, err := os.OpenFile(command.Opts.OutputFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 			if err != nil {
 				log.Warnf("OpenFile failed: %v", err)
 			}

--- a/cmd/subnet/subnet.go
+++ b/cmd/subnet/subnet.go
@@ -62,7 +62,7 @@ func BatchRun(net *net.IPNet) {
 
 func printResult(records define.Records) {
 	if command.Opts.OutputFile != "" {
-		f, err := os.OpenFile(command.Opts.OutputFile, os.O_CREATE|os.O_WRONLY, 0644)
+		f, err := os.OpenFile(command.Opts.OutputFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 		if err != nil {
 			log.Warnf("OpenFile failed: %v", err)
 		}

--- a/cmd/wildcard/wildcard.go
+++ b/cmd/wildcard/wildcard.go
@@ -1,0 +1,89 @@
+package wildcard
+
+import (
+	"encoding/json"
+	command "github.com/esonhugh/k8spider/cmd"
+	"github.com/miekg/dns"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"net"
+	"os"
+	"sort"
+	"strings"
+)
+
+func init() {
+	command.RootCmd.AddCommand(WildCardCmd)
+}
+
+var WildCardCmd = &cobra.Command{
+	Use:   "wildcard",
+	Short: "wildcard is a command to dump every record from CoreDNS",
+	Run: func(cmd *cobra.Command, args []string) {
+		if command.Opts.Zone == "" {
+			log.Warn("zone can't empty")
+			return
+		}
+
+		zone := dns.Fqdn(command.Opts.Zone)
+		DumpWildCard(zone)
+	},
+}
+
+func DumpWildCard(zone string) {
+	dnsNames := []string{
+		"any.any.svc." + zone,
+		"any.any.any.svc." + zone,
+	}
+
+	log.Debugf("same command: dig +short  %s %s", dnsNames[0], dnsNames[1])
+	var results []*net.SRV
+	for _, name := range dnsNames {
+		_, srvs, err := net.LookupSRV("", "", name)
+		if err != nil {
+			log.Warnln(err.Error())
+			continue
+		}
+
+		results = append(results, srvs...)
+	}
+
+	if len(results) == 0 {
+		log.Warn("CoreDNS Wildcards Found Nothing")
+		return
+	}
+
+	sort.Slice(results, func(i, j int) bool {
+		switch strings.Compare(results[i].Target, results[j].Target) {
+		case -1:
+			return true
+		case 0:
+			return results[i].Port < results[j].Port
+		case 1:
+			return false
+		}
+		return false
+	})
+
+	if command.Opts.OutputFile != "" {
+		f, err := os.OpenFile(command.Opts.OutputFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+		if err != nil {
+			log.Warnf("OpenFile failed: %v", err)
+		}
+		data, err := json.Marshal(results)
+		if err != nil {
+			log.Error(err)
+			return
+		}
+		_, err = f.Write(data)
+		if err != nil {
+			log.Error(err)
+			return
+		}
+		defer f.Close()
+	}
+
+	for _, srv := range results {
+		log.Println(srv.Target, srv.Port)
+	}
+}

--- a/cmd/wildcard/wildcard.go
+++ b/cmd/wildcard/wildcard.go
@@ -75,6 +75,7 @@ func DumpWildCard(zone string) {
 			log.Error(err)
 			return
 		}
+		data = append(data, '\n')
 		_, err = f.Write(data)
 		if err != nil {
 			log.Error(err)

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	_ "github.com/esonhugh/k8spider/cmd/axfr"
 	_ "github.com/esonhugh/k8spider/cmd/service"
 	_ "github.com/esonhugh/k8spider/cmd/subnet"
+	_ "github.com/esonhugh/k8spider/cmd/wildcard"
 )
 
 func main() {


### PR DESCRIPTION
1. 支持 k8s < v1.25 版本 dns服务使用 CoreDNS 时 Wildcards 利用 Ref: [cdk:service_discorvery_dns.go](https://github.com/cdk-team/CDK/blob/main/pkg/evaluate/service_discorvery_dns.go)
2. fix 使用 `os.OpenFile(..., os.O_CREATE|os.O_WRONLY, ...) ` 导致的文件覆盖问题。`OpenFile` 该打开模式为覆盖写入，也就是说如果，`DumpAXFR` 存在返回内容写入，然后 `Run` 写入的内存会覆盖写入从而导致之前写入内容丢失

新增 wildcard 子模块测试
```bash
root@nginx:~# ./k8spider-linux-static wildcard
INFO[0000] 10-244-0-2.kube-dns.kube-system.svc.cluster.local. 53
INFO[0000] 10-244-0-2.kube-dns.kube-system.svc.cluster.local. 9153
INFO[0000] 10-244-0-3.kube-dns.kube-system.svc.cluster.local. 53
INFO[0000] 10-244-0-3.kube-dns.kube-system.svc.cluster.local. 9153
INFO[0000] 172-18-0-2.kubernetes.default.svc.cluster.local. 6443
INFO[0000] kube-dns.kube-system.svc.cluster.local. 53
INFO[0000] kube-dns.kube-system.svc.cluster.local. 9153
INFO[0000] kubernetes.default.svc.cluster.local. 443
```

all 子模块测试
```bash
root@nginx:~# ./k8spider-linux-static all -c 10.96.0.1/24 -o test.txt
INFO[0000] 10-244-0-2.kube-dns.kube-system.svc.cluster.local. 53
INFO[0000] 10-244-0-2.kube-dns.kube-system.svc.cluster.local. 9153
INFO[0000] 10-244-0-3.kube-dns.kube-system.svc.cluster.local. 53
INFO[0000] 10-244-0-3.kube-dns.kube-system.svc.cluster.local. 9153
INFO[0000] 172-18-0-2.kubernetes.default.svc.cluster.local. 6443
INFO[0000] kube-dns.kube-system.svc.cluster.local. 53
INFO[0000] kube-dns.kube-system.svc.cluster.local. 9153
INFO[0000] kubernetes.default.svc.cluster.local. 443
ERRO[0000] Transfer failed: <nil>
INFO[0000] PTRrecord 10.96.0.1 --> kubernetes.default.svc.cluster.local.
INFO[0000] PTRrecord 10.96.0.10 --> kube-dns.kube-system.svc.cluster.local.
INFO[0000] SRVRecord: kubernetes.default.svc.cluster.local. --> kubernetes.default.svc.cluster.local.:443
INFO[0000] SRVRecord: kube-dns.kube-system.svc.cluster.local. --> kube-dns.kube-system.svc.cluster.local.:9153
INFO[0000] SRVRecord: kube-dns.kube-system.svc.cluster.local. --> kube-dns.kube-system.svc.cluster.local.:53
INFO[0000] {"Ip":"10.96.0.1","SvcDomain":"kubernetes.default.svc.cluster.local.","SrvRecords":[{"Cname":"kubernetes.default.svc.cluster.local.","Srv":[{"Target":"kubernetes.default.svc.cluster.local.","Port":443,"Priority":0,"Weight":100}]}]}
```

运行2次，产生2次结果，不会覆盖原有文件内容
```bash
[{"Target":"10-244-0-2.kube-dns.kube-system.svc.cluster.local.","Port":53,"Priority":0,"Weight":14},{"Target":"10-244-0-2.kube-dns.kube-system.svc.cluster.local.","Port":9153,"Priority":0,"Weight":14},{"Target":"10-244-0-3.kube-dns.kube-system.svc.cluster.local.","Port":53,"Priority":0,"Weight":14},{"Target":"10-244-0-3.kube-dns.kube-system.svc.cluster.local.","Port":9153,"Priority":0,"Weight":14},{"Target":"172-18-0-2.kubernetes.default.svc.cluster.local.","Port":6443,"Priority":0,"Weight":14},{"Target":"kube-dns.kube-system.svc.cluster.local.","Port":53,"Priority":0,"Weight":25},{"Target":"kube-dns.kube-system.svc.cluster.local.","Port":9153,"Priority":0,"Weight":25},{"Target":"kubernetes.default.svc.cluster.local.","Port":443,"Priority":0,"Weight":25}]
{"Ip":"10.96.0.1","SvcDomain":"kubernetes.default.svc.cluster.local.","SrvRecords":[{"Cname":"kubernetes.default.svc.cluster.local.","Srv":[{"Target":"kubernetes.default.svc.cluster.local.","Port":443,"Priority":0,"Weight":100}]}]}
{"Ip":"10.96.0.10","SvcDomain":"kube-dns.kube-system.svc.cluster.local.","SrvRecords":[{"Cname":"kube-dns.kube-system.svc.cluster.local.","Srv":[{"Target":"kube-dns.kube-system.svc.cluster.local.","Port":9153,"Priority":0,"Weight":33},{"Target":"kube-dns.kube-system.svc.cluster.local.","Port":53,"Priority":0,"Weight":33}]}]}
[{"Target":"10-244-0-2.kube-dns.kube-system.svc.cluster.local.","Port":53,"Priority":0,"Weight":14},{"Target":"10-244-0-2.kube-dns.kube-system.svc.cluster.local.","Port":9153,"Priority":0,"Weight":14},{"Target":"10-244-0-3.kube-dns.kube-system.svc.cluster.local.","Port":53,"Priority":0,"Weight":14},{"Target":"10-244-0-3.kube-dns.kube-system.svc.cluster.local.","Port":9153,"Priority":0,"Weight":14},{"Target":"172-18-0-2.kubernetes.default.svc.cluster.local.","Port":6443,"Priority":0,"Weight":14},{"Target":"kube-dns.kube-system.svc.cluster.local.","Port":53,"Priority":0,"Weight":25},{"Target":"kube-dns.kube-system.svc.cluster.local.","Port":9153,"Priority":0,"Weight":25},{"Target":"kubernetes.default.svc.cluster.local.","Port":443,"Priority":0,"Weight":25}]
{"Ip":"10.96.0.1","SvcDomain":"kubernetes.default.svc.cluster.local.","SrvRecords":[{"Cname":"kubernetes.default.svc.cluster.local.","Srv":[{"Target":"kubernetes.default.svc.cluster.local.","Port":443,"Priority":0,"Weight":100}]}]}
{"Ip":"10.96.0.10","SvcDomain":"kube-dns.kube-system.svc.cluster.local.","SrvRecords":[{"Cname":"kube-dns.kube-system.svc.cluster.local.","Srv":[{"Target":"kube-dns.kube-system.svc.cluster.local.","Port":53,"Priority":0,"Weight":33},{"Target":"kube-dns.kube-system.svc.cluster.local.","Port":9153,"Priority":0,"Weight":33}]}]}
```