### PR TITLE
fix: file overwriting problem

### DIFF
--- a/cmd/all/all.go
+++ b/cmd/all/all.go
@@ -74,7 +74,7 @@ func RunBatch(net *net.IPNet) {
 
 func printResult(records define.Records) {
 	if command.Opts.OutputFile != "" {
-		f, err := os.OpenFile(command.Opts.OutputFile, os.O_CREATE|os.O_WRONLY, 0644)
+		f, err := os.OpenFile(command.Opts.OutputFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 		if err != nil {
 			log.Warnf("OpenFile failed: %v", err)
 		}

--- a/cmd/axfr/axfr.go
+++ b/cmd/axfr/axfr.go
@@ -42,7 +42,7 @@ var AxfrCmd = &cobra.Command{
 			return
 		}
 		if command.Opts.OutputFile != "" {
-			f, err := os.OpenFile(command.Opts.OutputFile, os.O_CREATE|os.O_WRONLY, 0644)
+			f, err := os.OpenFile(command.Opts.OutputFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 			if err != nil {
 				log.Warnf("OpenFile failed: %v", err)
 			}

--- a/cmd/service/service.go
+++ b/cmd/service/service.go
@@ -29,7 +29,7 @@ var ServiceCmd = &cobra.Command{
 		}
 		records = scanner.ScanSvcForPorts(records)
 		if command.Opts.OutputFile != "" {
-			f, err := os.OpenFile(command.Opts.OutputFile, os.O_CREATE|os.O_WRONLY, 0644)
+			f, err := os.OpenFile(command.Opts.OutputFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 			if err != nil {
 				log.Warnf("OpenFile failed: %v", err)
 			}

--- a/cmd/subnet/subnet.go
+++ b/cmd/subnet/subnet.go
@@ -62,7 +62,7 @@ func BatchRun(net *net.IPNet) {
 
 func printResult(records define.Records) {
 	if command.Opts.OutputFile != "" {
-		f, err := os.OpenFile(command.Opts.OutputFile, os.O_CREATE|os.O_WRONLY, 0644)
+		f, err := os.OpenFile(command.Opts.OutputFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 		if err != nil {
 			log.Warnf("OpenFile failed: %v", err)
 		}

--- a/cmd/wildcard/wildcard.go
+++ b/cmd/wildcard/wildcard.go
@@ -28,7 +28,7 @@ var WildCardCmd = &cobra.Command{
 
 func printResult(records define.Records) {
 	if command.Opts.OutputFile != "" {
-		f, err := os.OpenFile(command.Opts.OutputFile, os.O_CREATE|os.O_WRONLY, 0644)
+		f, err := os.OpenFile(command.Opts.OutputFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 		if err != nil {
 			log.Warnf("OpenFile failed: %v", err)
 		}


### PR DESCRIPTION
fix 使用 os.OpenFile(..., os.O_CREATE|os.O_WRONLY, ...)  导致的文件覆盖问题。OpenFile 该打开模式为覆盖写入，也就是说如果 wildcard 存在返回内容写入，然后 Run 写入的内存会覆盖写入从而导致之前写入内容丢失